### PR TITLE
feat(score): 변경 R_REF, weight 2차원배열

### DIFF
--- a/src/EiMOS.h
+++ b/src/EiMOS.h
@@ -41,6 +41,8 @@
 #define ADC_RESOLUTION_MUTABLE
 #endif
 
+#define REF_CORRECTION_DIMENTION 2
+
 #include "ADS1X15.h"
 #include "MUX.h"
 #include "components.h"
@@ -50,7 +52,11 @@
 #define DEFAULT_NUMPIN 16
 #define DEFAULT_HONBA 0
 #define MAXSTICK 50
-#define MAXSTICK_100P 50
+#define MAXSTICK_10000P 16
+#define MAXSTICK_1000P 16
+#define MAXSTICK_500P 4
+#define MAXSTICK_100P 20
+#define MAXSTICK_100P_3SLOT 40
 
 #define RES 0
 #define CAP 1
@@ -88,6 +94,7 @@ class EiMOS
   EiMOS(int analog[], float v_unit[], float ref[]);
   EiMOS(int charge[], ADS1X15 *ext_adc[], float v_unit[], float ref[]);
   EiMOS(ADS1X15 *ext_adc[], float v_unit[], float ref[]);
+  EiMOS(ADS1X15 *ext_adc[], float v_unit[], float ref[][4]);
   MUX *getMUX();
   ENV *getENV();
   PIN *getPIN();
@@ -105,6 +112,7 @@ class EiMOS
   void setADCResolution(int a);
   void setExtADC(int gain, int bit, float vcc, int mode = 0);
   void setWeight(float a[]);
+  void setWeight(float weight[][4]);
   void setOffset(int a);
 
   void getScore(int scr[]);

--- a/src/components.h
+++ b/src/components.h
@@ -41,10 +41,18 @@ typedef struct PIN
   int button_mode[4];    // button pin controlling the display modes(INPUT_PULLUP)
   int button_honba;      // button pin controlling the honbas(INPUT_PULLUP)
   float RLC_per_unit[4]; // resistor/capacitor value per stick
-  float R_REF[4];        // reference resistor used to divide voltages
-  float R_PAR[4];        // resistance parallel to the capacitor; only for specific types of models
-                         // such as GOLD-stick CENTURY TENPAL
-  float weight[4];       // only for resistors. add weight to the ratio calculated
+#if REF_CORRECTION_DIMENTION == 1
+  float R_REF[4]; // reference resistor used to divide voltages (1 dimention)
+#elif REF_CORRECTION_DIMENTION == 2
+  float R_REF[4][4]; // reference resistor used to divide voltages (2 dimention)
+#endif
+  float R_PAR[4]; // resistance parallel to the capacitor; only for specific types of models
+                  // such as GOLD-stick CENTURY TENPAL
+#if REF_CORRECTION_DIMENTION == 1
+  float weight[4]; // only for resistors. add weight to the ratio calculated (1 dimention)
+#elif REF_CORRECTION_DIMENTION == 2
+  float weight[4][4]; // only for resistors. add weight to the ratio calculated (2 dimention)
+#endif
 } PIN;
 typedef struct VAL
 {


### PR DESCRIPTION
## Task Summary 🤩

- EiMOS의 RES 모드에서의 점수 측정 정확성 증대

<br>

## Changes 🗝️

### R_REF, weight
- 1차원, 2차원 배열 모두 사용 가능하도록
  + 이는 전처리기로 구분되기에 EiMOS.h의 REF_CORRECTION_DIMENTION 값을 1 or 2로 맞춰줘야 함
  + 이와 관련된 구조체, 메소드등이 모두 REF_CORRECTION_DIMENTION에 따라 다르게 정의됨

### EiMOS::numLoop
- 엣지케이스 처리 강화
  + 측정값에 따라 저항 개수가 음수가 되거나 해당 종류의 저항의 최대 개수를 넘는 경우 한계값으로 고정
  + 기본적으로 500점봉을 사용하도록 가정했지만 500점봉을 사용하지 않고 100점봉만을 사용하는 경우
  MAXSTICK_500P -> 0, MAXSTICK_100P -> 40으로 변경해야 함 (다만 한 종류의 저항이 많아질 경우 측정의 오차가 심해지기에 이는 비추천)

### EiMOS::RLCToNum
- 500점봉, 100점봉 측정의 역치값 재조정 (점봉이 없을경우 음수가 나오거나 하나일경우 0.8을 넘지 못함)

### EiMOS::scoreLoop
- 점봉통이 4칸인경우 500점봉칸 100점봉칸 분리 (500점봉, 100점봉이 혼재될 경우, 500점봉을 400점으로 계산하는 빈도가 잦음)

<br>

## To Reviewers 📢

<br>

## Self Checklist

-   [x] 적절한 라벨을 추가했습니다. (feat, fix, chore, etc..)
-   [x] 셀프 코드리뷰를 진행했습니다.
-   [ ] 리뷰어가 이해하기 어려운 영역에 대한 설명을 작성했습니다. (필요시)
-   [ ] 중점적으로 살펴보았으면 하는 영역에 대한 설명을 작성했습니다. (필요시)

